### PR TITLE
Added placeholder produce api

### DIFF
--- a/api/api_versions_api.go
+++ b/api/api_versions_api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"log/slog"
 	"talaria/protocol"
 )
 
@@ -24,8 +23,6 @@ func (a APIVersionsAPI) GeneratePayload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	slog.Debug("API Versions request", "req", apiVersionRequest)
 
 	response := NewAPIVersionsResponse(a.GetRequest().Header.RequestApiVersion)
 	return protocol.Encode(response)

--- a/api/metadata_api.go
+++ b/api/metadata_api.go
@@ -1,7 +1,6 @@
 package api
 
 import (
-	"log/slog"
 	"talaria/protocol"
 	"talaria/utils"
 	"time"
@@ -29,8 +28,6 @@ func (m MetadataAPI) GeneratePayload() ([]byte, error) {
 	if err != nil {
 		return nil, err
 	}
-
-	slog.Debug("Metadata request", "req", req)
 
 	response := GenerateMetadataResponse(m.GetRequest().Header.RequestApiVersion)
 	return protocol.Encode(response)

--- a/api/produce_api.go
+++ b/api/produce_api.go
@@ -1,37 +1,61 @@
 package api
 
-// import (
-// 	"lightweight-broker/protocol"
-// 	"lightweight-broker/protocol/models"
-// 	"log/slog"
-// )
+import (
+	"log/slog"
+	"talaria/protocol"
+	"talaria/utils"
+)
 
-// type ProduceAPI struct {
-// 	Request Request
-// }
+type ProduceAPI struct {
+	Request Request
+}
 
-// func (p ProduceAPI) Name() string {
-// 	return "Produce"
-// }
+func (p ProduceAPI) Name() string {
+	return "Produce"
+}
 
-// func (p ProduceAPI) GetRequest() Request {
-// 	return p.Request
-// }
+func (p ProduceAPI) GetRequest() Request {
+	return p.Request
+}
 
-// func (p ProduceAPI) GeneratePayload(encoder *protocol.Encoder) error {
-// 	req := models.ProduceRequest{}
-// 	err := req.Decode(p.GetRequest().Decoder, int(p.GetRequest().Header.APIVersion))
-// 	if err != nil {
-// 		return err
-// 	}
+func (p ProduceAPI) GetHeaderVersion(requestVersion int16) int16 {
+	return (&protocol.ProduceResponse{Version: requestVersion}).GetHeaderVersion()
+}
 
-// 	// for _, topic := range req.TopicData {
-// 	// 	for _, partition := range topic.PartitionData {
-// 	// 		slog.Debug("Received records", "records", partition.Records.String())
-// 	// 	}
-// 	// }
+// TODO: this is a placeholder function for now. We need to implement a backend that handles cluster topology in order to implement the API correctly and consume the messages.
+func (p ProduceAPI) GeneratePayload() ([]byte, error) {
+	req := protocol.ProduceRequest{}
+	_, err := protocol.VersionedDecode(p.GetRequest().Message, &req, p.GetRequest().Header.RequestApiVersion)
+	if err != nil {
+		return nil, err
+	}
 
-// 	slog.Debug("Produce request", "req", req)
+	resp := protocol.ProduceResponse{
+		Version: p.GetRequest().Header.RequestApiVersion,
+	}
 
-// 	return nil
-// }
+	for _, topic := range req.TopicData {
+		topicResponse := protocol.TopicProduceResponse{}
+		topicResponse.Version = resp.Version
+		topicResponse.Name = topic.Name
+
+		for _, partition := range topic.PartitionData {
+			slog.Debug("Received records", "records", partition.Records)
+
+			topicResponse.PartitionResponses = append(topicResponse.PartitionResponses, protocol.PartitionProduceResponse{
+				Version:    resp.Version,
+				Index:      partition.Index,
+				ErrorCode:  int16(utils.ErrNoError),
+				BaseOffset: partition.Records.BaseOffset,
+				// TODO: this needs to be implemented, see documentation for details
+				LogAppendTimeMs: -1,
+				LogStartOffset:  0,
+				// TODO: Don't forget to handle errors when the protocol is fully implemented
+			})
+		}
+
+		resp.Responses = append(resp.Responses, topicResponse)
+	}
+
+	return protocol.Encode(&resp)
+}

--- a/protocol/record_batch.go
+++ b/protocol/record_batch.go
@@ -148,12 +148,12 @@ func (r *RecordBatch) decode(pd packetDecoder, version int16) (err error) {
 		return err
 	}
 
-	remainingBytes, err := pd.getBytes()
+	remainingBytes, err := pd.getRawBytes(pd.remaining())
 	if err != nil {
 		return err
 	}
 
-	r.Records = remainingBytes[pd.remaining()-1:]
+	r.Records = remainingBytes
 
 	return err
 }

--- a/server.go
+++ b/server.go
@@ -106,8 +106,13 @@ Exit:
 				break Exit
 			}
 			apiHandler = api.MetadataAPI{Request: req}
-		// case protocol.ProduceKey:
-		// 	apiHandler = api.ProduceAPI{Request: request}
+		case (&protocol.ProduceRequest{}).GetKey():
+			req, err := makeRequest(messageBytes, client.conn, (&protocol.ProduceRequest{Version: header.RequestApiVersion}).GetHeaderVersion())
+			if err != nil {
+				slog.Error("error creating request", "err", err)
+				break Exit
+			}
+			apiHandler = api.ProduceAPI{Request: req}
 		default:
 			slog.Error("Unknown API key", "key", header.RequestApiKey)
 		}


### PR DESCRIPTION
The API supports bare bones produce functionality. It is able to receive a record batch and returns valid produce metadata. Once a proper backend is implemented, the API has to be implemented fully